### PR TITLE
Ability to disable weapon switching when alt-recepies are enabled

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,9 @@
 ---------------------------------------------------------------------------------------------------
+Version: 1.3.0
+Date: 14 August 2022
+  Features:
+    - Added an option to disable the weapon switching functionality while alternate recipes are enabled
+---------------------------------------------------------------------------------------------------
 Version: 1.2.9
 Date: 21 January 2022
   Changes:

--- a/control.lua
+++ b/control.lua
@@ -31,7 +31,7 @@ SWITCH_CHAINS = {
   "sws-sp-spiderling-sws-cannon-spiderling"
 }}
 
-local disable_weapon_switch = settings.startup["sws-disable-weapon-switch-whith-alt-recepies"].value
+local disable_weapon_switch = settings.startup["sws-disable-weapon-switch-whith-alt-recipes"].value
 local alternate_items = settings.startup["sws-show-alternate-items"].value
 
 on_spidertron_switched = script.generate_event_name()

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
     "name": "SpidertronWeaponSwitcher",
-    "version": "1.2.9",
+    "version": "1.3.0",
     "title": "Spidertron Weapon Switcher",
     "author": "Xorimuth",
     "description": "Allows the Spidertron to fire any type of weapon by cycling through different loadouts with Control + Tab.",

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -61,6 +61,8 @@ switch-spidertron-weapons=Next spidertron weapon
 
 [mod-setting-name]
 sws-show-alternate-items=Show alternate items and recipes [img=info]
+sws-disable-weapon-switch-whith-alt-recepies=Disable weapon switching with alt recepies [img=info]
 
 [mod-setting-description]
 sws-show-alternate-items=Adds a separate item and recipe for each spidertron+weapon combination
+sws-disable-weapon-switch-whith-alt-recepies=Removes the ability to switch between weapons when alternate recepies are enabled

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -61,8 +61,8 @@ switch-spidertron-weapons=Next spidertron weapon
 
 [mod-setting-name]
 sws-show-alternate-items=Show alternate items and recipes [img=info]
-sws-disable-weapon-switch-whith-alt-recepies=Disable weapon switching with alt recepies [img=info]
+sws-disable-weapon-switch-whith-alt-recipes=Disable weapon switching with alt recipes [img=info]
 
 [mod-setting-description]
 sws-show-alternate-items=Adds a separate item and recipe for each spidertron+weapon combination
-sws-disable-weapon-switch-whith-alt-recepies=Removes the ability to switch between weapons when alternate recepies are enabled
+sws-disable-weapon-switch-whith-alt-recipes=Removes the ability to switch between weapons when alternate recipes are enabled

--- a/settings.lua
+++ b/settings.lua
@@ -6,4 +6,11 @@ data:extend({
     default_value = false,
     order = "a"
   },
+  {
+    type = "bool-setting",
+    name = "sws-disable-weapon-switch-whith-alt-recepies",
+    setting_type = "startup",
+    default_value = true,
+    order = "a"
+  },
 })

--- a/settings.lua
+++ b/settings.lua
@@ -8,7 +8,7 @@ data:extend({
   },
   {
     type = "bool-setting",
-    name = "sws-disable-weapon-switch-whith-alt-recepies",
+    name = "sws-disable-weapon-switch-whith-alt-recipes",
     setting_type = "startup",
     default_value = true,
     order = "a"


### PR DESCRIPTION
Added an option to disable weapon switching with alt-recipes enabled so each spidertron has their own weapon. Previously you could build a separate cannon-spidertron but it had still all weapons available. This option changes that so it only has a cannon available. Applies to all spidertron types.